### PR TITLE
Init dashboard content

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import DashboardHome from '@/components/dashboard/DashboardHome'
 import { metaDescription } from '@/lib/meta'
 import { Metadata } from 'next'
 
@@ -7,10 +8,5 @@ export const metadata: Metadata = {
 }
 
 export default function DashboardPage() {
-	return (
-		<>
-			<p>DashboardPage</p>
-			{/* <DashboardHome /> */}
-		</>
-	)
+	return <DashboardHome />
 }

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -4,8 +4,8 @@ import { sidebarNames } from '@/lib/constants'
 export default function DashboardHeader() {
 	const { appSidebar } = sidebarNames
 	return (
-		<header className="w-full h-[--layout-header-height]">
-			<h1>Dashboard Header</h1>
+		<header className="w-full h-[--layout-header-height] flex justify-between items-center px-4 font-bold text-3xl">
+			<h1>Hello, Drummer! 👋</h1>
 			<SidebarTrigger
 				name={appSidebar}
 				className="flex md:hover-device:hidden"

--- a/src/components/dashboard/DashboardHome.tsx
+++ b/src/components/dashboard/DashboardHome.tsx
@@ -1,0 +1,13 @@
+import DashboardCard from '@/components/dashboard/card/DashboardCard'
+import WelcomeCardContent from '@/components/dashboard/card/WelcomeCardContent'
+
+export default function DashboardHome() {
+	return (
+		<div className="grid grid-cols-1 gap-4">
+			<DashboardCard
+				title="Welcome to The MaD App!"
+				content={<WelcomeCardContent />}
+			/>
+		</div>
+	)
+}

--- a/src/components/dashboard/DashboardPageLayout.tsx
+++ b/src/components/dashboard/DashboardPageLayout.tsx
@@ -4,6 +4,7 @@ import AppSidebar from '@/components/AppSidebar'
 import { sidebarNames } from '@/lib/constants'
 import BaseLayout from '../layout/BaseLayout'
 import DashboardHeader from './DashboardHeader'
+import Container from '@/components/layout/Container'
 
 export default function DashboardPageLayout({
 	children,
@@ -17,7 +18,9 @@ export default function DashboardPageLayout({
 				<AppSidebar name={appSidebar} openOnHover={true} />
 			</div>
 			<div className="flex-grow">
-				<BaseLayout header={<DashboardHeader />}>{children}</BaseLayout>
+				<BaseLayout header={<DashboardHeader />}>
+					<Container>{children}</Container>
+				</BaseLayout>
 			</div>
 		</SidebarProvider>
 	)

--- a/src/components/dashboard/card/DashboardCard.tsx
+++ b/src/components/dashboard/card/DashboardCard.tsx
@@ -1,0 +1,41 @@
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from '@/components/ui/card'
+import { ReactNode } from 'react'
+
+interface Props {
+	title: string
+	description?: string
+	content: ReactNode
+	footer?: ReactNode
+	isLoading?: boolean
+}
+
+export default function DashboardCard({
+	title,
+	content,
+	description,
+	footer,
+	isLoading,
+}: Props) {
+	if (isLoading) {
+		return <Card className="w-full">{/* Loading skeleton here */}</Card>
+	}
+
+	return (
+		<Card className="w-full">
+			<CardHeader>
+				<CardTitle className="text-2xl">
+					{title ? title : 'Card Title'}
+				</CardTitle>
+				{description && <CardDescription>{description}</CardDescription>}
+			</CardHeader>
+			{content ? content : <CardContent>Content, content, content</CardContent>}
+			{footer && footer}
+		</Card>
+	)
+}

--- a/src/components/dashboard/card/WelcomeCardContent.tsx
+++ b/src/components/dashboard/card/WelcomeCardContent.tsx
@@ -14,7 +14,7 @@ export default function WelcomeCardContent() {
 			<p>
 				📝 I&apos;d love to hear from you! Please send feedback about any issues
 				you encounter or features you&apos;d like to see in future updates to
-				admin.mad-app@gmail.com.
+				[ENTER FEEDBACK EMAIL ADDRESS HERE].
 			</p>
 			<p>
 				Ready to start your drumming journey?{' '}

--- a/src/components/dashboard/card/WelcomeCardContent.tsx
+++ b/src/components/dashboard/card/WelcomeCardContent.tsx
@@ -1,0 +1,27 @@
+import { CardContent } from '@/components/ui/card'
+import Link from 'next/link'
+
+export default function WelcomeCardContent() {
+	return (
+		<CardContent className="space-y-4">
+			<p className="font-bold text-lg">Project Status</p>
+			<p>
+				🚧 Work in Progress - This application is actively being developed.
+				Please excuse any rough edges you might encounter as I continue to
+				improve the experience.
+			</p>
+			<p className="font-bold text-lg">Feedback Welcome!</p>
+			<p>
+				📝 I&apos;d love to hear from you! Please send feedback about any issues
+				you encounter or features you&apos;d like to see in future updates to
+				admin.mad-app@gmail.com.
+			</p>
+			<p>
+				Ready to start your drumming journey?{' '}
+				<Link href="/course" className="text-blue-500 underline">
+					Go To The Course →
+				</Link>
+			</p>
+		</CardContent>
+	)
+}

--- a/src/components/layout/Container.tsx
+++ b/src/components/layout/Container.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export default function Container({ children }: { children: ReactNode }) {
+	return <div className="m-4">{children}</div>
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }


### PR DESCRIPTION
# Adding First Content To Dashboard

This PR is focused on adding the first content to the dashboard.

![init-dashboard-content](https://github.com/user-attachments/assets/2f61446d-e526-43f2-9937-360c9b6ee318)

## `DashboardHeader.tsx`
I updated the text to be displayed as well as the styling of the text.

## `Container.tsx`
I added this component to wrap the main content area in order to provide a margin around the content.

## `DashboardHome.tsx`
I added this component to house all content that will show on the `/dashboard` route `page.tsx`

### Grid Layout
This component establishes a `grid` layout inside which `DashboardCard`s will be places.

## `DashboardCard.tsx`
I built a reusable dashboard card component with dynamic title, description, content, footer. I included the scaffolding for a loading state for the future as well.

## `WelcomeCardContent.tsx`
Wrote out an initial welcome content to display to my first users. This is likely to change.